### PR TITLE
[DDST-627] Add Drush command.

### DIFF
--- a/src/Drush/Commands/BrokenReferenceCommands.php
+++ b/src/Drush/Commands/BrokenReferenceCommands.php
@@ -27,26 +27,16 @@ class BrokenReferenceCommands extends DrushCommands {
   protected BrokenReferenceStoreController $controller;
 
   /**
-   * The database connection.
-   *
-   * @var \Drupal\Core\Database\Connection
-   */
-  protected Connection $database;
-
-  /**
    * Constructs a new BrokenReferenceCommands object.
    *
    * @param \Drupal\broken_reference\Utility\BrokenReferenceFinder $finder
    *   The broken reference finder.
    * @param \Drupal\broken_reference\Controller\BrokenReferenceStoreController $controller
    *   The broken reference store controller.
-   * @param \Drupal\Core\Database\Connection $database
-   *   The database connection.
    */
-  public function __construct(BrokenReferenceFinder $finder, BrokenReferenceStoreController $controller, Connection $database) {
+  public function __construct(BrokenReferenceFinder $finder, BrokenReferenceStoreController $controller) {
     $this->finder = $finder;
     $this->controller = $controller;
-    $this->database = $database;
   }
 
   /**
@@ -56,7 +46,6 @@ class BrokenReferenceCommands extends DrushCommands {
     return new static(
       $container->get('broken_reference.finder'),
       $container->get('broken_reference.store_controller'),
-      $container->get('database')
     );
   }
 

--- a/src/Drush/Commands/BrokenReferenceCommands.php
+++ b/src/Drush/Commands/BrokenReferenceCommands.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\broken_reference\Drush\Commands;
+
+use Drupal\broken_reference\Controller\BrokenReferenceStoreController;
+use Drupal\broken_reference\Utility\BrokenReferenceFinder;
+use Drupal\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Database\Connection;
+use Drush\Attributes as CLI;
+use Drush\Attributes\HookSelector;
+use Drush\Commands\DrushCommands;
+
+class BrokenReferenceCommands extends DrushCommands {
+
+  /**
+   * The broken reference finder.
+   *
+   * @var \Drupal\broken_reference\Utility\BrokenReferenceFinder
+   */
+  protected BrokenReferenceFinder $finder;
+
+  /**
+   * The broken reference store controller.
+   *
+   * @var \Drupal\broken_reference\Controller\BrokenReferenceStoreController
+   */
+  protected BrokenReferenceStoreController $controller;
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected Connection $database;
+
+  /**
+   * Constructs a new BrokenReferenceCommands object.
+   *
+   * @param \Drupal\broken_reference\Utility\BrokenReferenceFinder $finder
+   *   The broken reference finder.
+   * @param \Drupal\broken_reference\Controller\BrokenReferenceStoreController $controller
+   *   The broken reference store controller.
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   */
+  public function __construct(BrokenReferenceFinder $finder, BrokenReferenceStoreController $controller, Connection $database) {
+    $this->finder = $finder;
+    $this->controller = $controller;
+    $this->database = $database;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('broken_reference.finder'),
+      $container->get('broken_reference.store_controller'),
+      $container->get('database')
+    );
+  }
+
+  /**
+   * Finds broken references via CLI.
+   */
+  #[CLI\Command(name: 'broken_reference:findBroken', aliases: ['br:fb'])]
+  #[CLI\Usage(name: 'broken_reference:findBroken', description: 'Finds broken references via CLI.')]
+  #[HookSelector(name: 'islandora-drush-utils-user-wrap')]
+  public function findBroken(): void {
+    $this->controller->clearBroken();
+    foreach ($this->finder->getReferenceFields() as $entityType => $config) {
+      $operations[] = [
+        '\Drupal\broken_reference\Batch\BrokenReferenceBatch::batchRun',
+        [$entityType, $config],
+      ];
+    }
+    $batch = [
+      'title' => 'Finding broken entity references...',
+      'operations' => $operations,
+      'init_message' => 'Commencing',
+      'progress_message' => 'Processed @current out of @total entity types.',
+      'error_message' => 'An error occurred during processing',
+      'finished' => '\Drupal\broken_reference\Batch\BrokenReferenceBatch::batchFinished',
+    ];
+    drush_op('batch_set', $batch);
+    drush_op('drush_backend_batch_process');
+
+    file_put_contents('/tmp/broken.log', json_encode($this->controller->getBroken()));
+  }
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line interface for managing broken references in Drupal, allowing users to find and process broken references efficiently.
	- Added functionality to log results in JSON format for better tracking and analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->