### PR TITLE
Avoid a group entity.

### DIFF
--- a/src/Utility/BrokenReferenceFinder.php
+++ b/src/Utility/BrokenReferenceFinder.php
@@ -118,6 +118,9 @@ class BrokenReferenceFinder {
         if ($entityType == 'paragraphs_library_item' && $field == 'paragraphs') {
           continue;
         }
+        if ($entityType === 'group_config_wrapper') {
+          continue;
+        }
 
         $bundles = array_keys($fieldInfo['bundles']);
         foreach ($bundles as $bundle) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of entity types by skipping processing for `group_config_wrapper`, enhancing overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->